### PR TITLE
Change default unauthenticated error message

### DIFF
--- a/bbtornado/__init__.py
+++ b/bbtornado/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '1.0.7'
+__version__ = '1.0.8'
 
 from tornado.util import ObjectDict
 

--- a/bbtornado/handlers.py
+++ b/bbtornado/handlers.py
@@ -19,7 +19,7 @@ from six import with_metaclass
 log = logging.getLogger('bbtornado')
 
 
-def authenticated(error_code=403, error_message="Not Found"):
+def authenticated(error_code=401, error_message="Unauthorized"):
     """Decorate methods with this to require that the user be logged in.
     If the user is not logged in, error_code will be set and error_message returned
     """


### PR DESCRIPTION
When authentication is required but not provided one should use the `401 Unauthorized`.